### PR TITLE
Move domain to www.gentoo.jp from www.gentoo.gr.jp

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,3 @@
 ## gentoojp.github.io [![Build Status](https://travis-ci.org/gentoojp/gentoojp.github.io.png?branch=source)](https://travis-ci.org/gentoojp/gentoojp.github.io)
 
-www.gentoo.gr.jp
+www.gentoo.jp

--- a/source/CNAME
+++ b/source/CNAME
@@ -1,1 +1,1 @@
-www.gentoo.gr.jp
+www.gentoo.jp

--- a/source/gentoo-news.xml
+++ b/source/gentoo-news.xml
@@ -7,7 +7,7 @@ permalink: /gentoo-news.xml
 
 <rdffeed type="news">
 	<title>Gentoo News (日本語版)</title> 
-	<link>http://www.gentoo.gr.jp/</link>
+	<link>http://www.gentoo.jp/</link>
 	<description>GentooJP News</description>
 	<feeditems />
 </rdffeed>

--- a/source/gentoojp-news.xml
+++ b/source/gentoojp-news.xml
@@ -7,7 +7,7 @@ permalink: /gentoojp-news.xml
 
 <rdffeed type="news">
 	<title>GentooJP News</title> 
-	<link>http://www.gentoo.gr.jp/</link>
+	<link>http://www.gentoo.jp/</link>
 	<description>GentooJP News</description>
 	<feeditems />
 </rdffeed>

--- a/source/jpmain/about-gentoojp.xml
+++ b/source/jpmain/about-gentoojp.xml
@@ -223,7 +223,7 @@
 		<body>
 			<p>
 			GentooJPでは情報発信の場として、ホームページを開設しています。<br />
-			GentooJPホームページアドレスは <uri>http://www.gentoo.gr.jp/</uri>です。<br />
+			GentooJPホームページアドレスは <uri>http://www.gentoo.jp/</uri>です。<br />
 			このホームページについてのお問い合わせは<mail link="www@gentoo.gr.jp">www@gentoo.gr.jp</mail>までお願いします。
 			</p>
 		</body>

--- a/source/jpmain/contribution.xml
+++ b/source/jpmain/contribution.xml
@@ -220,7 +220,7 @@ GentooJPでは、大きくわけて二種類のドキュメントを作成して
 
 <p>
 もう一つはGentooプロジェクトとは別にGentooJPが窓口になって作成しているドキュメントです。
-<uri link="http://www.gentoo.gr.jp/jpmain/docs-list.xml#doc_chap3">オリジナルドキュメント</uri>から参照することができます。
+<uri link="http://www.gentoo.jp/jpmain/docs-list.xml#doc_chap3">オリジナルドキュメント</uri>から参照することができます。
 </p>
 
 <p>

--- a/source/jpmain/developer.xml
+++ b/source/jpmain/developer.xml
@@ -48,7 +48,7 @@ GentooJP開発者になるための条件
 </chapter>
 
 <chapter>
-<title>www.gentoo.gr.jp サイトの更新方法</title>
+<title>www.gentoo.jp サイトの更新方法</title>
 
 <section>
 <title>更新について</title>
@@ -63,7 +63,7 @@ AuthorがGentooJPとなっているものの更新は自由に行なってくだ
 
 <p>
 更新の内容が不安な場合には事前にメーリングリストで話し合ってください。
-具体的な更新方法は<uri link="/jpmain/gentoojp-github-pages.html">www.gentoo.gr.jpのGithub Pagesについて</uri>を参照してください。
+具体的な更新方法は<uri link="/jpmain/gentoojp-github-pages.html">www.gentoo.jpのGithub Pagesについて</uri>を参照してください。
 </p>
 
 </body>
@@ -73,7 +73,7 @@ AuthorがGentooJPとなっているものの更新は自由に行なってくだ
 <title>ニュースの追加方法</title>
 <body>
 <p>
-ニュースとはwww.gentoo.gr.jpでアクセスしたときに出てくるGentooやGentooJPに関するお知らせのことです。
+ニュースとはwww.gentoo.jpでアクセスしたときに出てくるGentooやGentooJPに関するお知らせのことです。
 GentooJP開発者は誰でも自由にニュースを追加することができます。
 内容についてはGentooに関係することなら何でもOKです。
 一般の人向けである<uri link="/jpmain/news-submit.html">GentooJPニュース掲載手順</uri>も参照しておいてください。

--- a/source/jpmain/docs-list.xml
+++ b/source/jpmain/docs-list.xml
@@ -100,7 +100,7 @@ CVSの使い方などが記述されています。</ti>
 </tr>
 
 <tr>
-<ti><uri link="/jpmain/gentoojp-github-pages.html">www.gentoo.gr.jpのGithub Pagesについて</uri></ti>
+<ti><uri link="/jpmain/gentoojp-github-pages.html">www.gentoo.jpのGithub Pagesについて</uri></ti>
 <ti>GentooJPのGithub Pagesの管理方法などが記述されています。</ti>
 </tr>
 

--- a/source/jpmain/gentoojp-github-pages.xml
+++ b/source/jpmain/gentoojp-github-pages.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet href="/xsl/guide.xsl" type="text/xsl"?>
 <!DOCTYPE guide SYSTEM "/dtd/guide.dtd">
 <guide>
-  <title>www.gentoo.gr.jpのGithub Pagesについて</title>
+  <title>www.gentoo.jpのGithub Pagesについて</title>
   <author title="Author"><mail link="www@gentoo.jp">GentooJP</mail></author>
 
   <abstract>
@@ -62,7 +62,7 @@ $ <i>cd gentoojp.github.io</i></pre>
   &lt;title&gt;Github Pagesへ移行しました&lt;/title&gt;
 &lt;body&gt;
   &lt;p&gt;
-    GentooJPのホームページ(www.gentoo.gr.jp)はGithub Pagesへ移行しました。
+    GentooJPのホームページ(www.gentoo.jp)はGithub Pagesへ移行しました。
   &lt;/p&gt;
 &lt;/body&gt;</pre>
         <pre caption="ニュース記事をRSS用インデックスに追加">$ <i>$EDITOR source/jpnews/main/news-index.xml</i>

--- a/source/jpmain/news-submit.xml
+++ b/source/jpmain/news-submit.xml
@@ -21,7 +21,7 @@
     <title>ニュースとは</title>
     <body>
     <p>
-ここで説明するニュースとは、<uri link="/">www.gentoo.gr.jp</uri>でアクセスしたときに表示されるGentoo/GentooJP関連の話題のことです。
+ここで説明するニュースとは、<uri link="/">www.gentoo.jp</uri>でアクセスしたときに表示されるGentoo/GentooJP関連の話題のことです。
     </p>
     </body>
     </section>

--- a/source/xsl/gentoo-news.xsl
+++ b/source/xsl/gentoo-news.xsl
@@ -22,7 +22,7 @@
 				<xsl:for-each select="document('/jpnews/org/news-index.xml')/uris/uri[position()&lt;11]/text()">
 					<xsl:sort select="position()" order="ascending" /> 
 					<rdf:li>
-						<xsl:attribute name="rdf:resource">http://www.gentoo.gr.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></xsl:attribute>
+						<xsl:attribute name="rdf:resource">http://www.gentoo.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></xsl:attribute>
 					</rdf:li>
 				</xsl:for-each>
 			</rdf:Seq>
@@ -31,9 +31,9 @@
 
 	<xsl:for-each select="document('/jpnews/org/news-index.xml')/uris/uri[position()&lt;11]/text()">
 	<item>
-		<xsl:attribute name="rdf:about">http://www.gentoo.gr.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></xsl:attribute>
+		<xsl:attribute name="rdf:about">http://www.gentoo.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></xsl:attribute>
 		<title><xsl:value-of select="document(.)/news/title" /></title> 
-		<link>http://www.gentoo.gr.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></link>
+		<link>http://www.gentoo.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></link>
 		<dc:subject><xsl:value-of select="document(.)/news/@category" /></dc:subject>
 		<dc:creator><xsl:value-of select="document(.)/news/poster" /></dc:creator>
 		<!-- <dc:date><xsl:value-of select="document(.)/news/date" /></dc:date> -->

--- a/source/xsl/gentoojp-news.xsl
+++ b/source/xsl/gentoojp-news.xsl
@@ -22,7 +22,7 @@
 				<xsl:for-each select="document(document('/jpnews/allnews.xml')/news_indexes/file)/uris/uri[position()&lt;=5]/text()">
 				<xsl:sort select="substring-after(substring-after(substring-after(., '/'), '/'), '/')" order="descending" />
 					<rdf:li>
-						<xsl:attribute name="rdf:resource">http://www.gentoo.gr.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></xsl:attribute>
+						<xsl:attribute name="rdf:resource">http://www.gentoo.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></xsl:attribute>
 					</rdf:li>
 				</xsl:for-each>
 			</rdf:Seq>
@@ -32,9 +32,9 @@
 	<xsl:for-each select="document(document('/jpnews/allnews.xml')/news_indexes/file)/uris/uri[position()&lt;=5]/text()">
 	<xsl:sort select="substring-after(substring-after(substring-after(., '/'), '/'), '/')" order="descending" />
 	<item>
-		<xsl:attribute name="rdf:about">http://www.gentoo.gr.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></xsl:attribute>
+		<xsl:attribute name="rdf:about">http://www.gentoo.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></xsl:attribute>
 		<title><xsl:value-of select="document(.)/news/title" /></title> 
-		<link>http://www.gentoo.gr.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></link>
+		<link>http://www.gentoo.jp<xsl:value-of select="concat(substring-before(., 'xml'), 'html')" /></link>
 		<dc:subject><xsl:value-of select="document(.)/news/@category" /></dc:subject>
 		<dc:creator><xsl:value-of select="document(.)/news/poster" /></dc:creator>
 		<!-- <dc:date><xsl:value-of select="document(.)/news/date" /></dc:date> -->

--- a/source/xsl/guide.xsl
+++ b/source/xsl/guide.xsl
@@ -47,7 +47,7 @@
 
 			<body>
 					<div class="logo"><p>日本語：
-							[ <a href="http://www.gentoo.gr.jp/">GentooJP</a> ]
+							[ <a href="http://www.gentoo.jp/">GentooJP</a> ]
 							[ <a href="http://wiki.gentoo.gr.jp/">Wiki</a> ]
 							</p><p>英語：
 							[ <a href="http://www.gentoo.org/">Gentoo.org</a> ]


### PR DESCRIPTION
www.gentoo.gr.jp を www.gentoo.jp に書き換えました。
過去ニュース中のドメインについては、そのままとしてあります。