### PR TITLE
Add gentoo.gr.jp shutdown news to index

### DIFF
--- a/source/jpnews/main/news-index.xml
+++ b/source/jpnews/main/news-index.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <uris>
+<uri>/jpnews/main/20151115-shutdown-gentoo-gr-jp.xml</uri>
 <uri>/jpnews/main/20150225-github-issues.xml</uri>
 <uri>/jpnews/main/20150224-osc2015spring.xml</uri>
 <uri>/jpnews/main/20150215-new-domain.xml</uri>


### PR DESCRIPTION
#19 の追加漏れ分です。